### PR TITLE
pin python version to an exact version (again)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Vasundhara Gautam <vasundhara131719@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.7.10"
+python = "3.7.11" # this needs to be an exact pin because of the heroku poetry buildpack
 Flask = "^1.1.2"
 gunicorn = "^20.0.4"
 


### PR DESCRIPTION
this is how it used to be because of the heroku poetry buildpack but i recently switched to using my home computer which has a different default python3. I totally forgot about the buildpack and just widened the range. Anyway now I've added a comment to help my poor memory out for next time.