### PR TITLE
manually update lockfile

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -83,7 +83,7 @@ watchdog = ["watchdog"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "3.7.11" # this needs to be an exact pin because of the heroku poetry buildpack
+python-versions = "3.7.11"
 content-hash = "4d41430867698366f62982b11a36da683493e4bc69be2478a2c65481369c295e"
 
 [metadata.files]


### PR DESCRIPTION
so when there are non-functional changes to the pyproject.toml file (e.g., you remove a comment or move it around or whatever), poetry update does nothing. But the heroku poetry buildpack looks at the lockfile, not at your toml file, so you gotta delete the lockfile and start from scratch OR just manually edit it. i can't believe we're now 4 commits in, this is embarrassing